### PR TITLE
Add Reset Method and Long Press Command Support to ZoomView

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,14 @@ The `ZoomView` control exposes the following bindable properties:
 | `Content`             | `View`  | `null`  | The content to be displayed inside the zoomable area. |
 | `ZoomInOnDoubleTap`   | `bool`  | `true`  | If `true`, a double-tap will zoom in when the zoom level is at default. |
 | `ZoomOutOnDoubleTap`  | `bool`  | `true`  | If `true`, a double-tap will reset zoom when already zoomed in. |
+| `LongPressedCommand`  | `ICommand` | `null` | Command to execute when the view is long pressed. |
+
+
+## Methods
+
+| Method   | Description |
+|----------|-------------|
+| `Reset()` | Resets the zoom and position to the initial state. |
 
 
 
@@ -57,6 +65,7 @@ The `ZoomView` control exposes the following bindable properties:
 
 ---
 
+
 ## Usage
 
 1. Add the `ZoomView` control to your XAML file:
@@ -65,10 +74,33 @@ The `ZoomView` control exposes the following bindable properties:
                 xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
                 xmlns:zoomview="clr-namespace:Plugin.Maui.ZoomView;assembly=Plugin.Maui.ZoomView"
                 x:Class="YourNamespace.MainPage">
-       <zoomview:ZoomView>
+       <zoomview:ZoomView
+           LongPressedCommand="{Binding LongPressedCommand}">
            <!-- Add your content here -->
        </zoomview:ZoomView>
    </ContentPage>
+   ```
+
+2. To reset the zoom programmatically, call the `Reset()` method:
+   ```csharp
+   MyZoomView.Reset();
+   ```
+
+3. To handle long press, bind the `LongPressedCommand` property to a command in your ViewModel or code-behind:
+   ```csharp
+   public ICommand LongPressedCommand { get; }
+
+   public MainPage()
+   {
+       InitializeComponent();
+       LongPressedCommand = new Command(OnLongPressed);
+       MyZoomView.LongPressedCommand = LongPressedCommand;
+   }
+
+   private async void OnLongPressed()
+   {
+       await DisplayAlert("Long Press", "ZoomView was long pressed!", "OK");
+   }
    ```
 > ⚠️ **Note:**  
 > `ZoomView` is best suited for non-interactive content like `Image`, `Label`, or static custom views. While interactive controls (e.g., `Entry`, `Editor`, `Button`) can be placed inside, they may not behave reliably during zoom or pan. Use with caution.

--- a/samples/ZoomViewSample/MainPage.xaml
+++ b/samples/ZoomViewSample/MainPage.xaml
@@ -3,10 +3,13 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:zoom="clr-namespace:Plugin.Maui.ZoomView;assembly=Plugin.Maui.ZoomView"
              x:Class="ZoomViewSample.MainPage">
-            <zoom:ZoomView VerticalOptions="Center">
-                <Image 
-                Source="dotnet_bot.png" 
-                Aspect="AspectFit"
-                SemanticProperties.Description="dot net bot in a hovercraft number nine" />
-            </zoom:ZoomView>        
+    <VerticalStackLayout Spacing="16" Padding="24">
+        <zoom:ZoomView x:Name="MyZoomView" VerticalOptions="Center" LongPressedCommand="{Binding LongPressedCommand}">
+            <Image x:Name="MyImage"
+                   Source="dotnet_bot.png"
+                   Aspect="AspectFit"
+                   SemanticProperties.Description="dot net bot in a hovercraft number nine" />
+        </zoom:ZoomView>
+        <Button Text="Reset Zoom" Clicked="OnResetZoomClicked" />
+    </VerticalStackLayout>
 </ContentPage>

--- a/samples/ZoomViewSample/MainPage.xaml.cs
+++ b/samples/ZoomViewSample/MainPage.xaml.cs
@@ -1,13 +1,27 @@
-﻿namespace ZoomViewSample;
+﻿using System.Windows.Input;
+
+namespace ZoomViewSample;
 
 public partial class MainPage : ContentPage
 {
+    public ICommand LongPressedCommand { get; }
 
+    public MainPage()
+    {
+        InitializeComponent();
+        BindingContext = this;
+        LongPressedCommand = new Command(OnLongPressed);
+        MyZoomView.LongPressedCommand = LongPressedCommand;
+    }
 
-	public MainPage()
-	{
-		InitializeComponent();
-	}
+    private async void OnLongPressed()
+    {
+        await DisplayAlert("Alert", "Long pressed!", "OK");
+    }
 
-	
+    private void OnResetZoomClicked(object sender, EventArgs e)
+    {
+        MyZoomView.Reset();
+    }
+
 }

--- a/src/Plugin.Maui.ZoomView/IZoomView.cs
+++ b/src/Plugin.Maui.ZoomView/IZoomView.cs
@@ -3,18 +3,31 @@ using System.Windows.Input;
 
 namespace Plugin.Maui.ZoomView;
 
-public interface IZoomView: IView
+public interface IZoomView : IView
 {
-    public View Content {get; set;}
+    /// <summary>
+    /// Gets or sets the content of the view.
+    /// </summary>
+    public View Content { get; set; }
 
-    public bool ZoomInOnDoubleTap {get; set;}
 
-    public bool ZoomOutOnDoubleTap {get; set;}
+    /// <summary>
+    /// Gets or sets a value indicating whether a double-tap gesture should zoom into the content
+    /// </summary>
+    public bool ZoomInOnDoubleTap { get; set; }
+
+
+    /// <summary>
+    /// Gets or sets a value indicating whether a double-tap gesture should reset the zoom level
+    /// </summary>
+    public bool ZoomOutOnDoubleTap { get; set; }
+
 
     /// <summary>
     /// Resets the zoom and position to the initial state.
     /// </summary>
     public void Reset();
+
 
     /// <summary>
     /// Command to execute when the view is long pressed.

--- a/src/Plugin.Maui.ZoomView/IZoomView.cs
+++ b/src/Plugin.Maui.ZoomView/IZoomView.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Windows.Input;
 
 namespace Plugin.Maui.ZoomView;
 
@@ -9,5 +10,15 @@ public interface IZoomView: IView
     public bool ZoomInOnDoubleTap {get; set;}
 
     public bool ZoomOutOnDoubleTap {get; set;}
+
+    /// <summary>
+    /// Resets the zoom and position to the initial state.
+    /// </summary>
+    public void Reset();
+
+    /// <summary>
+    /// Command to execute when the view is long pressed.
+    /// </summary>
+    public ICommand LongPressedCommand { get; set; }
 
 }

--- a/src/Plugin.Maui.ZoomView/Platforms/Android/PlatformZoomView.cs
+++ b/src/Plugin.Maui.ZoomView/Platforms/Android/PlatformZoomView.cs
@@ -4,6 +4,7 @@ using Paint = Android.Graphics.Paint;
 using Color = Android.Graphics.Color;
 using Android.Views;
 using Android.Widget;
+using Android.OS;
 
 namespace Plugin.Maui.ZoomView.Platforms.Android;
 
@@ -42,7 +43,7 @@ public class PlatformZoomView : FrameLayout
 
 	private const int LongPressTimeout = 2000; // ms
 	private bool _longPressTriggered = false;
-	private System.Timers.Timer? _longPressTimer;
+	private Handler? _handler;
 	#endregion
 
 	#region  Override
@@ -172,7 +173,7 @@ public class PlatformZoomView : FrameLayout
 				touchLastY = y;
 				scrolling = false;
 				_longPressTriggered = false;
-				_handler = new Android.OS.Handler();
+				_handler = new Handler(Looper.MainLooper);
 				_handler.PostDelayed(() =>
 				{
 					if (!_longPressTriggered && smoothZoom == 1.0f)
@@ -190,17 +191,17 @@ public class PlatformZoomView : FrameLayout
 						scrolling = true;
 						e.Action = MotionEventActions.Cancel;
 						base.DispatchTouchEvent(e);
-						_longPressTimer?.Stop();
+						_handler?.RemoveCallbacksAndMessages(null);
 						return;
 					}
 					smoothZoomX -= dx / zoom;
 					smoothZoomY -= dy / zoom;
-					_longPressTimer?.Stop();
+					_handler?.RemoveCallbacksAndMessages(null);
 					return;
 				}
 				break;
 			case MotionEventActions.Up:
-				_longPressTimer?.Stop();
+				_handler?.RemoveCallbacksAndMessages(null);
 				if (l < 30.0f)
 				{
 					if (Java.Lang.JavaSystem.CurrentTimeMillis() - lastTapTime < 500)
@@ -219,7 +220,7 @@ public class PlatformZoomView : FrameLayout
 				}
 				break;
 			case MotionEventActions.Cancel:
-				_longPressTimer?.Stop();
+			_handler?.RemoveCallbacksAndMessages(null);
 				break;
 		}
 	

--- a/src/Plugin.Maui.ZoomView/Platforms/Android/PlatformZoomView.cs
+++ b/src/Plugin.Maui.ZoomView/Platforms/Android/PlatformZoomView.cs
@@ -172,18 +172,15 @@ public class PlatformZoomView : FrameLayout
 				touchLastY = y;
 				scrolling = false;
 				_longPressTriggered = false;
-				_longPressTimer = new System.Timers.Timer(LongPressTimeout);
-				_longPressTimer.Elapsed += (s, args) =>
+				_handler = new Android.OS.Handler();
+				_handler.PostDelayed(() =>
 				{
-					_longPressTimer?.Stop();
 					if (!_longPressTriggered && smoothZoom == 1.0f)
 					{
 						_longPressTriggered = true;
 						LongPressed?.Invoke(this, EventArgs.Empty);
 					}
-				};
-				_longPressTimer.AutoReset = false;
-				_longPressTimer.Start();
+				}, LongPressTimeout);
 				break;
 			case MotionEventActions.Move:
 				if (scrolling || (smoothZoom > 1.0f && l > 30.0f))

--- a/src/Plugin.Maui.ZoomView/Platforms/Android/ZoomViewHandler.cs
+++ b/src/Plugin.Maui.ZoomView/Platforms/Android/ZoomViewHandler.cs
@@ -27,4 +27,20 @@ public partial class ZoomViewHandler
         }
     }
 
+    public static void MapLongPressedCommand(ZoomViewHandler handler, IZoomView view)
+    {
+        if (handler?.PlatformView == null)
+            return;
+
+        // Remove previous event handler if any
+        // (No direct way to remove all handlers from outside, so be aware of possible multiple subscriptions)
+        if (view.LongPressedCommand != null)
+        {
+            handler.PlatformView.LongPressed += (s, e) =>
+            {
+                if (view.LongPressedCommand.CanExecute(null))
+                    view.LongPressedCommand.Execute(null);
+            };
+        }
+    }
 }

--- a/src/Plugin.Maui.ZoomView/Platforms/Android/ZoomViewHandler.cs
+++ b/src/Plugin.Maui.ZoomView/Platforms/Android/ZoomViewHandler.cs
@@ -1,53 +1,64 @@
+
+
 using Microsoft.Maui.Platform;
 using Plugin.Maui.ZoomView.Platforms.Android;
-
-namespace Plugin.Maui.ZoomView;
-
-public partial class ZoomViewHandler
+namespace Plugin.Maui.ZoomView
 {
-    protected override PlatformZoomView CreatePlatformView()
+    public partial class ZoomViewHandler
     {
-        return new PlatformZoomView(Context);
-    }
-    public static void MapContent(ZoomViewHandler handler, IZoomView view)
-    {
-        if (handler.MauiContext is null) throw new InvalidOperationException("MauiContext can not be null");
-
-        if (handler.PlatformView is not null && view.Content is not null)
+        private EventHandler? _previousLongPressedHandler;
+        protected override PlatformZoomView CreatePlatformView()
         {
-            handler.PlatformView.AddView(view.Content.ToPlatform(handler.MauiContext));
+            return new PlatformZoomView(Context);
         }
-    }
-
-    public static void MapZoomOnDoubleTap(ZoomViewHandler handler, IZoomView view)
-    {
-        if (handler is not null && handler.PlatformView is not null)
+        public static void MapContent(ZoomViewHandler handler, IZoomView view)
         {
-            handler.PlatformView.SetZoomOnDoubleTap(view.ZoomInOnDoubleTap, view.ZoomOutOnDoubleTap);
-        }
-    }
+            if (handler.MauiContext is null) throw new InvalidOperationException("MauiContext can not be null");
 
-    public static void MapLongPressedCommand(ZoomViewHandler handler, IZoomView view)
-    {
-        if (handler?.PlatformView == null)
-            return;
-
-        // Remove previous event handler if any
-        if (handler._previousLongPressedHandler != null)
-        {
-            handler.PlatformView.LongPressed -= handler._previousLongPressedHandler;
-        }
-
-        // Add new event handler if command is not null
-        if (view.LongPressedCommand != null)
-        {
-            EventHandler newHandler = (s, e) =>
+            if (handler.PlatformView is not null && view.Content is not null)
             {
-                if (view.LongPressedCommand.CanExecute(null))
-                    view.LongPressedCommand.Execute(null);
-            };
-            handler.PlatformView.LongPressed += newHandler;
-            handler._previousLongPressedHandler = newHandler;
+                handler.PlatformView.AddView(view.Content.ToPlatform(handler.MauiContext));
+            }
+        }
+
+        public static void MapZoomOnDoubleTap(ZoomViewHandler handler, IZoomView view)
+        {
+            if (handler is not null && handler.PlatformView is not null)
+            {
+                handler.PlatformView.SetZoomOnDoubleTap(view.ZoomInOnDoubleTap, view.ZoomOutOnDoubleTap);
+            }
+        }
+
+        public static void MapLongPressedCommand(ZoomViewHandler handler, IZoomView view)
+        {
+            if (handler?.PlatformView == null)
+                return;
+
+            // Remove previous event handler if any
+            if (handler._previousLongPressedHandler != null)
+            {
+                handler.PlatformView.LongPressed -= handler._previousLongPressedHandler;
+            }
+
+            // Add new event handler if command is not null
+            if (view.LongPressedCommand != null)
+            {
+                EventHandler newHandler = (s, e) =>
+                {
+                    if (view.LongPressedCommand.CanExecute(null))
+                        view.LongPressedCommand.Execute(null);
+                };
+                handler.PlatformView.LongPressed += newHandler;
+                handler._previousLongPressedHandler = newHandler;
+            }
+        }
+
+        public static void MapReset(ZoomViewHandler handler, IZoomView view)
+        {
+            if (handler?.PlatformView == null)
+                return;
+                
+            handler.PlatformView?.ResetZoom();
         }
     }
 }

--- a/src/Plugin.Maui.ZoomView/Platforms/Android/ZoomViewHandler.cs
+++ b/src/Plugin.Maui.ZoomView/Platforms/Android/ZoomViewHandler.cs
@@ -33,14 +33,21 @@ public partial class ZoomViewHandler
             return;
 
         // Remove previous event handler if any
-        // (No direct way to remove all handlers from outside, so be aware of possible multiple subscriptions)
+        if (handler._previousLongPressedHandler != null)
+        {
+            handler.PlatformView.LongPressed -= handler._previousLongPressedHandler;
+        }
+
+        // Add new event handler if command is not null
         if (view.LongPressedCommand != null)
         {
-            handler.PlatformView.LongPressed += (s, e) =>
+            EventHandler newHandler = (s, e) =>
             {
                 if (view.LongPressedCommand.CanExecute(null))
                     view.LongPressedCommand.Execute(null);
             };
+            handler.PlatformView.LongPressed += newHandler;
+            handler._previousLongPressedHandler = newHandler;
         }
     }
 }

--- a/src/Plugin.Maui.ZoomView/Platforms/iOS/PlatformZoomView.cs
+++ b/src/Plugin.Maui.ZoomView/Platforms/iOS/PlatformZoomView.cs
@@ -6,6 +6,12 @@ namespace Plugin.Maui.ZoomView.Platforms.iOS;
 
 public class PlatformZoomView : UIScrollView
 {
+    private EventHandler? _longPressed;
+    public event EventHandler? LongPressed
+    {
+        add { _longPressed += value; }
+        remove { _longPressed -= value; }
+    }
     ZoomViewDoubleTap? _doubleTap;
 
     public bool ZoomInOnDoubleTap;
@@ -21,6 +27,29 @@ public class PlatformZoomView : UIScrollView
         DelaysContentTouches = false;
         BouncesZoom = false;
         ViewForZoomingInScrollView += GetViewForZooming!;
+
+        // Long press gesture
+        var longPress = new UILongPressGestureRecognizer(OnLongPressed)
+        {
+            MinimumPressDuration = 2 // seconds
+        };
+        AddGestureRecognizer(longPress);
+    }
+
+    private void OnLongPressed(UILongPressGestureRecognizer recognizer)
+    {
+        if (recognizer.State == UIGestureRecognizerState.Began)
+        {
+            // Only fire long press if at default scale (not zoomed)
+            if (ZoomScale == 1f)
+                _longPressed?.Invoke(this, EventArgs.Empty);
+        }
+    }
+    public void ResetZoom()
+    {
+        SetZoomScale(1f, true);
+        // Optionally, reset content offset if needed
+        SetContentOffset(CGPoint.Empty, true);
     }
 
     public override void LayoutSubviews()

--- a/src/Plugin.Maui.ZoomView/Platforms/iOS/ZoomViewHandler.cs
+++ b/src/Plugin.Maui.ZoomView/Platforms/iOS/ZoomViewHandler.cs
@@ -43,14 +43,21 @@ public partial class ZoomViewHandler
         if (handler?.PlatformView == null)
             return;
 
-        // Remove previous event handler if any (not implemented here for brevity)
+        // Remove previous event handler if any
+        if (handler._longPressedHandler != null)
+        {
+            handler.PlatformView.LongPressed -= handler._longPressedHandler;
+            handler._longPressedHandler = null;
+        }
+
         if (view.LongPressedCommand != null)
         {
-            handler.PlatformView.LongPressed += (s, e) =>
+            handler._longPressedHandler = (s, e) =>
             {
                 if (view.LongPressedCommand.CanExecute(null))
                     view.LongPressedCommand.Execute(null);
             };
+            handler.PlatformView.LongPressed += handler._longPressedHandler;
         }
     }
 }

--- a/src/Plugin.Maui.ZoomView/Platforms/iOS/ZoomViewHandler.cs
+++ b/src/Plugin.Maui.ZoomView/Platforms/iOS/ZoomViewHandler.cs
@@ -1,63 +1,74 @@
+    
 using Microsoft.Maui.Platform;
 using Plugin.Maui.ZoomView.Platforms.iOS;
 using UIKit;
 
-namespace Plugin.Maui.ZoomView;
-
-public partial class ZoomViewHandler
+namespace Plugin.Maui.ZoomView
 {
-    protected override PlatformZoomView CreatePlatformView()
+
+    public partial class ZoomViewHandler
     {
-        return new PlatformZoomView();
-    }
-
-    protected override void DisconnectHandler(PlatformZoomView platformView)
-    {
-        platformView.Disconnect();
-        base.DisconnectHandler(platformView);
-    }
-
-
-    public static void MapContent(ZoomViewHandler handler, IZoomView view)
-    {
-        if (handler.MauiContext is null) throw new InvalidOperationException("MauiContext can not be null");
-
-        if (handler.PlatformView is not null && view.Content is not null)
+        private EventHandler? _longPressedHandler;
+        protected override PlatformZoomView CreatePlatformView()
         {
-            var content = view.Content.ToPlatform(handler.MauiContext);
-            handler.PlatformView.AddSubview(content);
+            return new PlatformZoomView();
         }
 
-    }
-
-    public static void MapZoomOnDoubleTap(ZoomViewHandler handler, IZoomView view)
-    {
-        if (handler is not null && handler.PlatformView is not null)
+        protected override void DisconnectHandler(PlatformZoomView platformView)
         {
-            handler.PlatformView.SetupDoubleTapGesture(view.ZoomInOnDoubleTap, view.ZoomOutOnDoubleTap);
-        }
-    }
-
-    public static void MapLongPressedCommand(ZoomViewHandler handler, IZoomView view)
-    {
-        if (handler?.PlatformView == null)
-            return;
-
-        // Remove previous event handler if any
-        if (handler._longPressedHandler != null)
-        {
-            handler.PlatformView.LongPressed -= handler._longPressedHandler;
-            handler._longPressedHandler = null;
+            platformView.Disconnect();
+            base.DisconnectHandler(platformView);
         }
 
-        if (view.LongPressedCommand != null)
+
+        public static void MapContent(ZoomViewHandler handler, IZoomView view)
         {
-            handler._longPressedHandler = (s, e) =>
+            if (handler.MauiContext is null) throw new InvalidOperationException("MauiContext can not be null");
+
+            if (handler.PlatformView is not null && view.Content is not null)
             {
-                if (view.LongPressedCommand.CanExecute(null))
-                    view.LongPressedCommand.Execute(null);
-            };
-            handler.PlatformView.LongPressed += handler._longPressedHandler;
+                var content = view.Content.ToPlatform(handler.MauiContext);
+                handler.PlatformView.AddSubview(content);
+            }
+
+        }
+
+        public static void MapZoomOnDoubleTap(ZoomViewHandler handler, IZoomView view)
+        {
+            if (handler is not null && handler.PlatformView is not null)
+            {
+                handler.PlatformView.SetupDoubleTapGesture(view.ZoomInOnDoubleTap, view.ZoomOutOnDoubleTap);
+            }
+        }
+
+        public static void MapLongPressedCommand(ZoomViewHandler handler, IZoomView view)
+        {
+            if (handler?.PlatformView == null)
+                return;
+
+            // Remove previous event handler if any
+            if (handler._longPressedHandler != null)
+            {
+                handler.PlatformView.LongPressed -= handler._longPressedHandler;
+                handler._longPressedHandler = null;
+            }
+
+            if (view.LongPressedCommand != null)
+            {
+                handler._longPressedHandler = (s, e) =>
+                {
+                    if (view.LongPressedCommand.CanExecute(null))
+                        view.LongPressedCommand.Execute(null);
+                };
+                handler.PlatformView.LongPressed += handler._longPressedHandler;
+            }
+        }
+        public static void MapReset(ZoomViewHandler handler, IZoomView view)
+        {
+            if (handler?.PlatformView == null)
+                return;
+                
+            handler.PlatformView?.ResetZoom();
         }
     }
 }

--- a/src/Plugin.Maui.ZoomView/Platforms/iOS/ZoomViewHandler.cs
+++ b/src/Plugin.Maui.ZoomView/Platforms/iOS/ZoomViewHandler.cs
@@ -8,7 +8,7 @@ public partial class ZoomViewHandler
 {
     protected override PlatformZoomView CreatePlatformView()
     {
-       return new PlatformZoomView();
+        return new PlatformZoomView();
     }
 
     protected override void DisconnectHandler(PlatformZoomView platformView)
@@ -17,25 +17,40 @@ public partial class ZoomViewHandler
         base.DisconnectHandler(platformView);
     }
 
-    
+
     public static void MapContent(ZoomViewHandler handler, IZoomView view)
     {
-        if(handler.MauiContext is null) throw new InvalidOperationException("MauiContext can not be null");
-        
+        if (handler.MauiContext is null) throw new InvalidOperationException("MauiContext can not be null");
+
         if (handler.PlatformView is not null && view.Content is not null)
         {
             var content = view.Content.ToPlatform(handler.MauiContext);
             handler.PlatformView.AddSubview(content);
         }
-        
+
     }
 
     public static void MapZoomOnDoubleTap(ZoomViewHandler handler, IZoomView view)
     {
-       if(handler is not null && handler.PlatformView is not null)
-       {    
-            handler.PlatformView.SetupDoubleTapGesture(view.ZoomInOnDoubleTap,view.ZoomOutOnDoubleTap);
-       }
+        if (handler is not null && handler.PlatformView is not null)
+        {
+            handler.PlatformView.SetupDoubleTapGesture(view.ZoomInOnDoubleTap, view.ZoomOutOnDoubleTap);
+        }
     }
 
+    public static void MapLongPressedCommand(ZoomViewHandler handler, IZoomView view)
+    {
+        if (handler?.PlatformView == null)
+            return;
+
+        // Remove previous event handler if any (not implemented here for brevity)
+        if (view.LongPressedCommand != null)
+        {
+            handler.PlatformView.LongPressed += (s, e) =>
+            {
+                if (view.LongPressedCommand.CanExecute(null))
+                    view.LongPressedCommand.Execute(null);
+            };
+        }
+    }
 }

--- a/src/Plugin.Maui.ZoomView/Plugin.Maui.ZoomView.csproj
+++ b/src/Plugin.Maui.ZoomView/Plugin.Maui.ZoomView.csproj
@@ -1,4 +1,4 @@
-﻿	<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<TargetFrameworks>net9.0-android;net9.0-ios;net9.0</TargetFrameworks>

--- a/src/Plugin.Maui.ZoomView/ZoomView.cs
+++ b/src/Plugin.Maui.ZoomView/ZoomView.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Windows.Input;
 
 namespace Plugin.Maui.ZoomView;
 
@@ -13,6 +14,19 @@ public class ZoomView : View, IZoomView
 	{
 		get => (View)GetValue(ContentProperty);
 		set => SetValue(ContentProperty, value);
+	}
+
+	// LongPressedCommand BindableProperty
+	public static readonly BindableProperty LongPressedCommandProperty =
+		BindableProperty.Create(nameof(LongPressedCommand), typeof(ICommand), typeof(ZoomView), default(ICommand));
+
+	/// <summary>
+	/// Command to execute when the view is long pressed.
+	/// </summary>
+	public ICommand LongPressedCommand
+	{
+		get => (ICommand)GetValue(LongPressedCommandProperty);
+		set => SetValue(LongPressedCommandProperty, value);
 	}
 
 	public static readonly BindableProperty ZoomInOnDoubleTapProperty =
@@ -54,15 +68,26 @@ public class ZoomView : View, IZoomView
 		get => (float)GetValue(ZoomProperty);
 		set => SetValue(ZoomProperty, value);
 	}
-    protected override void OnBindingContextChanged()
-    {
-        base.OnBindingContextChanged();
+	/// <summary>
+	/// Resets the zoom and position to the initial state.
+	/// </summary>
+	public void Reset()
+	{
+		if (Handler is ZoomViewHandler handler)
+		{
+			ZoomViewHandler.MapReset(handler, this);
+		}
+	}
 
-        if (Content is VisualElement ve)
-        {
-            ve.BindingContext = BindingContext;
-        }
-    }
+	protected override void OnBindingContextChanged()
+	{
+		base.OnBindingContextChanged();
+
+		if (Content is VisualElement ve)
+		{
+			ve.BindingContext = BindingContext;
+		}
+	}
 }
 
 public static class AppBuilderExtension

--- a/src/Plugin.Maui.ZoomView/ZoomViewHandler.cs
+++ b/src/Plugin.Maui.ZoomView/ZoomViewHandler.cs
@@ -19,7 +19,7 @@ public partial class ZoomViewHandler : ViewHandler<IZoomView, PlatformView>
     [nameof(IZoomView.Content)] = MapContent,
     [nameof(IZoomView.ZoomInOnDoubleTap)] = MapZoomOnDoubleTap,
     [nameof(IZoomView.ZoomOutOnDoubleTap)] = MapZoomOnDoubleTap,
-    ["Reset"] = MapReset,
+    [nameof(IZoomView.Reset)] = MapReset,
     [nameof(IZoomView.LongPressedCommand)] = MapLongPressedCommand,
   };
 

--- a/src/Plugin.Maui.ZoomView/ZoomViewHandler.cs
+++ b/src/Plugin.Maui.ZoomView/ZoomViewHandler.cs
@@ -19,11 +19,18 @@ public partial class ZoomViewHandler : ViewHandler<IZoomView, PlatformView>
     [nameof(IZoomView.Content)] = MapContent,
     [nameof(IZoomView.ZoomInOnDoubleTap)] = MapZoomOnDoubleTap,
     [nameof(IZoomView.ZoomOutOnDoubleTap)] = MapZoomOnDoubleTap,
+    ["Reset"] = MapReset,
+    [nameof(IZoomView.LongPressedCommand)] = MapLongPressedCommand,
   };
 
    
 
     public ZoomViewHandler() : base(PropertyMapper, null)
-  {
-  }
+    {
+    }
+    public static void MapReset(ZoomViewHandler handler, IZoomView view)
+    {
+        handler?.PlatformView?.ResetZoom();
+    }
+
 }

--- a/src/Plugin.Maui.ZoomView/ZoomViewHandler.cs
+++ b/src/Plugin.Maui.ZoomView/ZoomViewHandler.cs
@@ -20,17 +20,11 @@ public partial class ZoomViewHandler : ViewHandler<IZoomView, PlatformView>
     [nameof(IZoomView.ZoomInOnDoubleTap)] = MapZoomOnDoubleTap,
     [nameof(IZoomView.ZoomOutOnDoubleTap)] = MapZoomOnDoubleTap,
     [nameof(IZoomView.Reset)] = MapReset,
-    [nameof(IZoomView.LongPressedCommand)] = MapLongPressedCommand,
+    [nameof(IZoomView.LongPressedCommand)] = MapLongPressedCommand
   };
 
-   
-
-    public ZoomViewHandler() : base(PropertyMapper, null)
-    {
-    }
-    public static void MapReset(ZoomViewHandler handler, IZoomView view)
-    {
-        handler?.PlatformView?.ResetZoom();
-    }
-
+  public ZoomViewHandler() : base(PropertyMapper, null)
+  {
+  }
+  
 }

--- a/src/Plugin.Maui.ZoomView/ZoomViewHandler.net.cs
+++ b/src/Plugin.Maui.ZoomView/ZoomViewHandler.net.cs
@@ -22,5 +22,15 @@ namespace Plugin.Maui.ZoomView
         {
             throw new NotImplementedException();
         }
+
+        public static void MapReset(ZoomViewHandler handler, IZoomView view)
+        {
+            throw new NotImplementedException();
+        }
+
+        public static void MapLongPressedCommand(ZoomViewHandler handler, IZoomView view)
+        {
+            throw new NotImplementedException();
+        }
     }
 }


### PR DESCRIPTION
This PR introduces two new features to the Plugin.Maui.ZoomView control:

**1. Reset() Method**
Adds a Reset() method that programmatically restores the zoom level and position of the ZoomView to its initial state.

**Why is this needed?**
In image galleries, if a user zooms into an image and closes it, the next image may open in the same zoomed-in state. Calling Reset() ensures that each newly loaded image starts at the default zoom level and position.

**2. LongPressedCommand Bindable Property**
Adds a LongPressedCommand bindable property, enabling developers to execute a custom ICommand when the ZoomView is long-pressed.

**Why is this needed?**
This provides a simple way to trigger actions like showing a context menu (e.g., download, share, or favorite options) when the user long-presses an image.

